### PR TITLE
Run Insights-Client After Each Workshop Excercise

### DIFF
--- a/1-initial_setup.yml
+++ b/1-initial_setup.yml
@@ -6,3 +6,7 @@
   roles:
     - storage
     - common
+    - redhatinsights.insights.insights_client
+  tasks:
+    - name: run the insights-client and upload to c.rh.c
+      shell: insights-client

--- a/1-initial_setup.yml
+++ b/1-initial_setup.yml
@@ -7,6 +7,6 @@
     - storage
     - common
     - redhatinsights.insights.insights_client
-  tasks:
+  post_tasks:
     - name: run the insights-client and upload to c.rh.c
       shell: insights-client

--- a/2-sap_prepare.yml
+++ b/2-sap_prepare.yml
@@ -8,6 +8,11 @@
     - redhat_sap.sap_rhsm
     - redhat_sap.sap_hostagent
 
+  post_tasks:
+    - name: run the insights-client and upload to c.rh.c
+      shell: insights-client
+
+
 - name: preconfigure hana and deploy hana
   hosts: "tag_app_sap_hana_ha_demo:&tag_role_hana"
   become_method: su
@@ -15,14 +20,17 @@
   roles:
     - sap-hana-preconfigure
 
+  post_tasks:
+    - name: run the insights-client and upload to c.rh.c
+      shell: insights-client
+
 - name: preconfigure netweaver and install s4 app
   hosts: "tag_app_sap_hana_ha_demo:&tag_role_s4app"
 
   roles:
     - sap-netweaver-preconfigure
 
-- name: run the insights client
-  hosts: "tag_app_sap_hana_ha_demo:!tag_role_sapgui"
-  tasks:
+  post_tasks:
     - name: run the insights-client and upload to c.rh.c
       shell: insights-client
+

--- a/2-sap_prepare.yml
+++ b/2-sap_prepare.yml
@@ -20,3 +20,9 @@
 
   roles:
     - sap-netweaver-preconfigure
+
+- name: run the insights client
+  hosts: "tag_app_sap_hana_ha_demo:!tag_role_sapgui"
+  tasks:
+    - name: run the insights-client and upload to c.rh.c
+      shell: insights-client

--- a/3-sap_deploy_hana.yml
+++ b/3-sap_deploy_hana.yml
@@ -35,5 +35,6 @@
 #      when: sap_hana_hsr_role == 'primary'
 
 
+  post_tasks:
     - name: run the insights-client and upload to c.rh.c
       shell: insights-client

--- a/3-sap_deploy_hana.yml
+++ b/3-sap_deploy_hana.yml
@@ -33,3 +33,7 @@
 #      register: db_overwrite_cmd
 #      failed_when: false
 #      when: sap_hana_hsr_role == 'primary'
+
+
+    - name: run the insights-client and upload to c.rh.c
+      shell: insights-client

--- a/4-sap_deploy_s4.yml
+++ b/4-sap_deploy_s4.yml
@@ -15,6 +15,10 @@
         var: hostvars['hana_primary']['ip_address']
       when: sap_hana_hsr_role == 'primary'
 
+  post_tasks:
+    - name: run insights client and send data to c.rh.c
+      command: insights-client
+
 - name: preconfigure netweaver and install s4 app
   hosts: "tag_app_sap_hana_ha_demo:&tag_role_s4app"
 #  become_method: su
@@ -69,10 +73,6 @@
           failed_when: false
       when: sap_hana_hsr_role == 'primary'
 
-- name: run insights client
-  hosts: "tag_app_sap_hana_ha_demo:!tag_role_sapgui"
-
-  tasks:
-    - name: run insights client
+    - name: run insights client and send data to c.rh.c
       command: insights-client
-      failed_when: false
+

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,0 +1,5 @@
+---
+
+collections:
+   - name: redhatinsights.insights
+     source: https://galaxy.ansible.com

--- a/sap_failover_maint.yml
+++ b/sap_failover_maint.yml
@@ -397,3 +397,9 @@
       retries: 300
       delay: 10
       failed_when: false
+
+- name: rerun the insights client
+  hosts: "tag_app_sap_hana_ha_demo:&tag_role_hana"
+  tasks:
+    - name: run the insights-client and upload to c.rh.c
+      shell: insights-client 


### PR DESCRIPTION
This PR addresses:
- ensuring the systems are properly registered to insights (will work with either RHSM or satellite, by default we defer to the registration information provided by subscription-manager)
- re-run the insights client after each exercise (ensures any changes made during that exercise will be denoted within the insights webUI)